### PR TITLE
MySqlの外部キー制約無効化

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\CommitOrderCalculator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 /**
@@ -133,7 +134,7 @@ class ORMPurger implements PurgerInterface
         }
 
         $connection = $this->em->getConnection();
-        if ($this->purgeMode === self::PURGE_MODE_TRUNCATE) {
+        if ($platform instanceof MySqlPlatform && $this->purgeMode === self::PURGE_MODE_TRUNCATE) {
             $connection->query('SET FOREIGN_KEY_CHECKS=0');
         }
         foreach($orderedTables as $tbl) {
@@ -144,7 +145,7 @@ class ORMPurger implements PurgerInterface
                 $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }
         }
-        if ($this->purgeMode === self::PURGE_MODE_TRUNCATE) {
+        if ($platform instanceof MySqlPlatform && $this->purgeMode === self::PURGE_MODE_TRUNCATE) {
             $connection->query('SET FOREIGN_KEY_CHECKS=1');
         }
     }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -133,6 +133,9 @@ class ORMPurger implements PurgerInterface
         }
 
         $connection = $this->em->getConnection();
+        if ($this->purgeMode === self::PURGE_MODE_TRUNCATE) {
+            $connection->query('SET FOREIGN_KEY_CHECKS=0');
+        }
         foreach($orderedTables as $tbl) {
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
                 $tbl = $connection->quoteIdentifier($tbl);
@@ -140,6 +143,9 @@ class ORMPurger implements PurgerInterface
             } else {
                 $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }
+        }
+        if ($this->purgeMode === self::PURGE_MODE_TRUNCATE) {
+            $connection->query('SET FOREIGN_KEY_CHECKS=1');
         }
     }
 


### PR DESCRIPTION
`MySqlPlatform` かつ `purgeMode = truncate` 時に外部キー制約を無効化して実行するように修正しました
